### PR TITLE
chore: adding new location for in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ Java idiomatic client for [Access Approval][product-docs].
 - [Product Documentation][product-docs]
 - [Client Library Documentation][javadocs]
 
+{% note %}
+
+Notes:
+
+The latest source code of this library has moved to
+[google-cloud-java/google-java-accessapproval](
+https://github.com/googleapis/google-cloud-java/tree/main/java-accessapproval)
+{% endnote %}
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -8,14 +8,11 @@ Java idiomatic client for [Access Approval][product-docs].
 - [Product Documentation][product-docs]
 - [Client Library Documentation][javadocs]
 
-{% note %}
 
-Notes:
-
-The latest source code of this library has moved to
+:bus: In October 2022, the latest source code of this library has moved to
 [google-cloud-java/google-java-accessapproval](
-https://github.com/googleapis/google-cloud-java/tree/main/java-accessapproval)
-{% endnote %}
+https://github.com/googleapis/google-cloud-java/tree/main/java-accessapproval).
+We keep this repository public for users to read old code.
 
 ## Quickstart
 


### PR DESCRIPTION
The google-cloud-java monorepo started working. Now it's time to add note in the README so that users know the new location of the source code.