### PR TITLE
chore: add java-docs-samples in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ https://github.com/googleapis/google-cloud-java/tree/main/java-accessapproval).
 This repository will be archived in the future.
 Future releases will appear in the new repository (https://github.com/googleapis/google-cloud-java/releases).
 The Maven artifact coordinates (`com.google.cloud:google-cloud-accessapproval`) remain the same.
+Sample code is in https://github.com/GoogleCloudPlatform/java-docs-samples.
 
 ## Quickstart
 


### PR DESCRIPTION
The code in this repository has moved to https://github.com/googleapis/google-cloud-java/tree/main/java-accessapproval and https://github.com/GoogleCloudPlatform/java-docs-samples